### PR TITLE
add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # sliderule-python
+[![Binder](https://mybinder.org/badge_logo.svg)](https://gke.mybinder.org/v2/gh/ICESat2-SlideRule/sliderule-python/main?urlpath=lab)
+[![badge](https://img.shields.io/static/v1.svg?logo=Jupyter&label=PangeoBinderAWS&message=us-west-2&color=orange)](https://aws-uswest2-binder.pangeo.io/v2/gh/ICESat2-SlideRule/sliderule-python/main?urlpath=lab)
+[![Documentation Status](https://readthedocs.org/projects/sliderule-python/badge/?version=latest)](https://sliderule-python.readthedocs.io/en/latest/?badge=latest)
 
 SlideRule's Python client makes it easier to interact with SlideRule from a Python script.
 


### PR DESCRIPTION
adds two binder badges (GCP and AWS) and a read the docs badge. 

You can do fancier setups with binder badges as described here https://github.com/jupyterhub/repo2docker-action this PR only adds the bare minimum config 

closes #14 