### PR TITLE
Update binder environment JLab>=3, cartopy>=0.20

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,9 @@ dependencies:
   - geopandas
   - h5py
   - ipykernel
-  - ipywidgets
-  - ipyleaflet
-  - jupyterlab>=3
+  - ipywidgets>=7.6,<8.0
+  - ipyleaflet>=0.14
+  - jupyterlab=3
   - jupyterlab_widgets
   - matplotlib
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -3,22 +3,23 @@ name: sliderule
 channels:
   - conda-forge
 dependencies:
-  - python=3.8
-  - setuptools_scm
   - cartopy
+  - geopandas
+  - h5py
   - ipykernel
   - ipywidgets
   - ipyleaflet
-  - tk
+  - jupyterlab>=3
   - matplotlib
   - numpy
   - pandas
-  - geopandas
-  - h5py
   - pip
   - pyproj
-  - scipy
-  - shapely
+  - python=3.8
   - requests
+  - scipy
+  - setuptools_scm
+  - shapely
+  - tk
   - pip:
       - -e ./

--- a/environment.yml
+++ b/environment.yml
@@ -10,11 +10,13 @@ dependencies:
   - ipywidgets
   - ipyleaflet
   - jupyterlab>=3
+  - jupyterlab_widgets
   - matplotlib
   - numpy
   - pandas
   - pip
   - pyproj
+  - pytables
   - python=3.8
   - requests
   - scipy

--- a/postBuild
+++ b/postBuild
@@ -1,2 +1,0 @@
-jupyter labextension install --clean @jupyter-widgets/jupyterlab-manager \
-   jupyter-matplotlib jupyter-leaflet


### PR DESCRIPTION
Closes #49

* alphabatize environment.yml packages
* pin jlab>=3 (it's been out for a while and conveniently removes the need for the `postBuild` configuration file. JLab extensions get enabled automatically when installed from conda-forge)
* pin cartopy>=0.20 