### PR TITLE
fix: include `world_copy_jump` to webmercator map

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update -y && \
 ENV JOBS 2
 
 ENV CFLAGS="-fPIC"
-ENV ZLIB_VERSION=1.2.11
+ENV ZLIB_VERSION=1.2.12
 RUN wget -q http://zlib.net/zlib-${ZLIB_VERSION}.tar.gz && \
     tar -xzf zlib-${ZLIB_VERSION}.tar.gz && \
     cd zlib-${ZLIB_VERSION} && \

--- a/sliderule/ipysliderule.py
+++ b/sliderule/ipysliderule.py
@@ -1512,7 +1512,7 @@ class leaflet:
         # create basemap in projection
         if (projection == 'Global'):
             self.map = ipyleaflet.Map(center=kwargs['center'],
-                zoom=9, max_zoom=15,
+                zoom=9, max_zoom=15, world_copy_jump=True,
                 attribution_control=kwargs['attribution'],
                 basemap=ipyleaflet.basemaps.Esri.WorldTopoMap)
             self.crs = 'EPSG:3857'


### PR DESCRIPTION
fixes a problem where user's would draw a box on one longitudinal copy of the map, and data would appear 360 degrees away on another copy.